### PR TITLE
Fix README demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Flap.AI is an engaging browser-based HTML game inspired by the classic Flappy Bi
 
 ## Live Demo
 
-Play the game online using GitHub Pages:  
-[https://jarvuslin.github.io/flap.ai/flap.html](https://jarvuslin.github.io/flap.ai/)
+Play the game online using GitHub Pages:
+[https://jarvuslin.github.io/flap.ai/flap.html](https://jarvuslin.github.io/flap.ai/flap.html)
 
 ## Description
 


### PR DESCRIPTION
## Summary
- fix incorrect hyperlink in README live demo section

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f6f37b9c483318da00e7b631e9f9c